### PR TITLE
Issues 2: Gnorm Compiler

### DIFF
--- a/bin/compile.php
+++ b/bin/compile.php
@@ -26,7 +26,8 @@ try {
 
     $config = \Gnorm\GnormTwigConfiguration::decode($options['c']);
 
-    $compiler = new \Gnorm\GnormCompiler($repo_root, $config, $options['b']);
+    $isBuild = 'TRUE' == $options['b'] ? true : false;
+    $compiler = new \Gnorm\GnormCompiler($repo_root, $config, $isBuild);
     $compiler->execute();
 }
 catch (Throwable $exception) {


### PR DESCRIPTION
## Description
* Passed $isBuild as a boolean to fix twig gulp watch and build tasks fixes #2.