### PR TITLE
Updating required twig version to be compatible with Drupal 9.5 and 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
   "require": {
       "php": "^7.4 || ^8.0",
       "ext-json": "*",
-      "twig/twig": "2.15.3"
+      "twig/twig": "^2.15.3 || ^3.5.0"
   },
   "autoload": {
       "psr-4": {


### PR DESCRIPTION
Looking through the code we are using the following classes from twig:

- \Twig\Environment
- \Twig\Extension\ExtensionInterface
- \Twig\Extension\AbstractExtension
- \Twig\TwigFilter
- \Twig\TwigFunction

I compared the 2.x and 3.x code, and these classes do not appear to have changed in any meaningful way between the versions.

Version constraints were determined by `^2.5.3` allows the same or newer versions of 2.x from the current requirement. `^3.5.0` matches what Drupal core 10.1.5 (the current version) uses.